### PR TITLE
Refresh gallery photos after permission grant

### DIFF
--- a/app/src/main/java/com/example/basicgallery/ui/gallery/GalleryScreen.kt
+++ b/app/src/main/java/com/example/basicgallery/ui/gallery/GalleryScreen.kt
@@ -132,7 +132,12 @@ fun GalleryRoute(viewModel: GalleryViewModel) {
     DisposableEffect(lifecycleOwner, permissions) {
         val observer = LifecycleEventObserver { _, event ->
             if (event == Lifecycle.Event.ON_RESUME) {
-                hasPermission = context.hasAnyPermission(permissions)
+                val hasPermissionNow = context.hasAnyPermission(permissions)
+                hasPermission = hasPermissionNow
+
+                if (hasPermissionNow) {
+                    viewModel.loadPhotos(forceRefresh = true)
+                }
             }
         }
         lifecycleOwner.lifecycle.addObserver(observer)


### PR DESCRIPTION
This pull request updates the app to refresh gallery photos automatically whenever the user grants the necessary permissions. This ensures the displayed gallery content remains up to date without requiring a manual refresh.