### PR TITLE
Add tests and improve FullscreenMediaScreen edit logic

### DIFF
--- a/app/src/androidTest/java/com/example/basicgallery/ui/gallery/FullscreenMediaScreenTest.kt
+++ b/app/src/androidTest/java/com/example/basicgallery/ui/gallery/FullscreenMediaScreenTest.kt
@@ -1,0 +1,57 @@
+package com.example.basicgallery.ui.gallery
+
+import android.net.Uri
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.example.basicgallery.R
+import com.example.basicgallery.data.model.MediaType
+import com.example.basicgallery.data.model.PhotoItem
+import com.example.basicgallery.ui.theme.BasicGalleryTheme
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class FullscreenMediaScreenTest {
+
+    @get:Rule
+    val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun fullscreenPhoto_whenOpenedFromPhotos_showsEditButton() {
+        setFullscreenContent(onEditPhoto = {})
+
+        composeRule.onNodeWithText(composeRule.activity.getString(R.string.edit)).assertExists()
+    }
+
+    @Test
+    fun fullscreenPhoto_whenOpenedFromTrash_hidesEditButton() {
+        setFullscreenContent(onEditPhoto = null)
+
+        composeRule.onNodeWithText(composeRule.activity.getString(R.string.edit)).assertDoesNotExist()
+    }
+
+    private fun setFullscreenContent(onEditPhoto: ((PhotoItem) -> Unit)?) {
+        val photo = PhotoItem(
+            id = 1L,
+            contentUri = Uri.parse("content://com.example.basicgallery.test/photo/1"),
+            dateTakenMillis = 0L,
+            mediaType = MediaType.PHOTO
+        )
+
+        composeRule.setContent {
+            BasicGalleryTheme {
+                FullscreenMediaScreen(
+                    mediaItems = listOf(photo),
+                    initialMediaUri = photo.contentUri,
+                    onBack = {},
+                    onEditPhoto = onEditPhoto,
+                    onDelete = {},
+                    onCurrentMediaChanged = {}
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/basicgallery/ui/gallery/GalleryScreen.kt
+++ b/app/src/main/java/com/example/basicgallery/ui/gallery/GalleryScreen.kt
@@ -287,6 +287,15 @@ fun GalleryRoute(viewModel: GalleryViewModel) {
                 } else {
                     uiState.photos
                 }
+                val onEditPhotoRequest: ((PhotoItem) -> Unit)? = if (selectedMediaOpenedFromTrash) {
+                    null
+                } else {
+                    { media ->
+                        editorPhotoUri = media.contentUri.toString()
+                        editorPhotoId = media.id
+                        editorPhotoDateTakenMillis = media.dateTakenMillis
+                    }
+                }
                 val onDeleteRequest: ((Uri) -> Unit)? = if (selectedMediaOpenedFromTrash) {
                     null
                 } else {
@@ -303,11 +312,7 @@ fun GalleryRoute(viewModel: GalleryViewModel) {
                     mediaItems = currentMedia,
                     initialMediaUri = mediaUri,
                     onBack = { selectedMediaUri = null },
-                    onEditPhoto = { media ->
-                        editorPhotoUri = media.contentUri.toString()
-                        editorPhotoId = media.id
-                        editorPhotoDateTakenMillis = media.dateTakenMillis
-                    },
+                    onEditPhoto = onEditPhotoRequest,
                     onDelete = onDeleteRequest,
                     onCurrentMediaChanged = { currentMediaItem ->
                         selectedMediaUri = currentMediaItem.contentUri.toString()
@@ -834,11 +839,11 @@ private fun rememberMediaImageLoader(): ImageLoader {
 }
 
 @Composable
-private fun FullscreenMediaScreen(
+internal fun FullscreenMediaScreen(
     mediaItems: List<PhotoItem>,
     initialMediaUri: Uri,
     onBack: () -> Unit,
-    onEditPhoto: (PhotoItem) -> Unit,
+    onEditPhoto: ((PhotoItem) -> Unit)?,
     onDelete: ((Uri) -> Unit)?,
     onCurrentMediaChanged: (PhotoItem) -> Unit
 ) {
@@ -899,8 +904,10 @@ private fun FullscreenMediaScreen(
                         .padding(vertical = 8.dp)
                 ) {
                     if (currentMedia.mediaType == MediaType.PHOTO) {
-                        TextButton(onClick = { onEditPhoto(currentMedia) }) {
-                            Text(text = stringResource(id = R.string.edit))
+                        if (onEditPhoto != null) {
+                            TextButton(onClick = { onEditPhoto(currentMedia) }) {
+                                Text(text = stringResource(id = R.string.edit))
+                            }
                         }
                         TextButton(
                             onClick = { onDelete?.invoke(currentMedia.contentUri) },


### PR DESCRIPTION
Refactored `onEditPhoto` to handle trash state effectively and added tests to ensure correct visibility of the edit button in `FullscreenMediaScreen`.