### PR TITLE
Add EditedPhotoNameCodec for metadata handling in MediaStore

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,8 +15,8 @@ android {
         applicationId = "com.example.basicgallery"
         minSdk = 29
         targetSdk = 36
-        versionCode = 1
-        versionName = "1.0"
+        versionCode = 2
+        versionName = "1.0.3"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/com/example/basicgallery/data/EditedPhotoNameCodec.kt
+++ b/app/src/main/java/com/example/basicgallery/data/EditedPhotoNameCodec.kt
@@ -1,0 +1,52 @@
+package com.example.basicgallery.data
+
+import java.util.Locale
+
+internal object EditedPhotoNameCodec {
+
+    fun buildDisplayName(
+        originalName: String?,
+        mimeType: String,
+        sourceDateTakenMillis: Long,
+        nowMillis: Long = System.currentTimeMillis()
+    ): String {
+        val baseName = originalName
+            ?.substringBeforeLast('.', missingDelimiterValue = originalName)
+            ?.takeIf { it.isNotBlank() }
+            ?: "IMG_$nowMillis"
+
+        val extension = when (mimeType.lowercase(Locale.US)) {
+            MIME_TYPE_PNG -> "png"
+            MIME_TYPE_WEBP -> "webp"
+            else -> "jpg"
+        }
+
+        return if (sourceDateTakenMillis > 0L) {
+            "${baseName}_edited_from_${sourceDateTakenMillis}_at_${nowMillis}.$extension"
+        } else {
+            "${baseName}_edited_${nowMillis}.$extension"
+        }
+    }
+
+    fun parseSourceDateTakenMillis(displayName: String?): Long? {
+        return displayName
+            ?.let { EDITED_NAME_DATE_REGEX.find(it) }
+            ?.groupValues
+            ?.getOrNull(1)
+            ?.toLongOrNull()
+            ?.takeIf { it > 0L }
+    }
+
+    fun resolveDateTakenMillis(
+        dateTakenMillis: Long,
+        dateAddedSeconds: Long,
+        displayName: String?
+    ): Long {
+        return parseSourceDateTakenMillis(displayName)
+            ?: if (dateTakenMillis > 0L) dateTakenMillis else dateAddedSeconds * 1000L
+    }
+
+    private const val MIME_TYPE_PNG = "image/png"
+    private const val MIME_TYPE_WEBP = "image/webp"
+    private val EDITED_NAME_DATE_REGEX = Regex("_edited_from_(\\d+)_at_\\d+\\.[^.]+$")
+}

--- a/app/src/main/java/com/example/basicgallery/data/MediaStoreGalleryRepository.kt
+++ b/app/src/main/java/com/example/basicgallery/data/MediaStoreGalleryRepository.kt
@@ -8,6 +8,7 @@ import android.database.Cursor
 import android.graphics.Bitmap
 import android.graphics.ImageDecoder
 import android.graphics.Rect
+import android.media.ExifInterface
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
@@ -19,6 +20,9 @@ import com.example.basicgallery.data.model.PhotoCrop
 import com.example.basicgallery.data.model.PhotoItem
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 import java.util.Locale
 import kotlin.math.roundToInt
 
@@ -102,6 +106,7 @@ class MediaStoreGalleryRepository(
             MediaStore.Images.Media._ID,
             MediaStore.Images.Media.DATE_TAKEN,
             MediaStore.Images.Media.DATE_ADDED,
+            MediaStore.MediaColumns.DISPLAY_NAME,
             MediaStore.MediaColumns.SIZE
         )
 
@@ -144,14 +149,20 @@ class MediaStoreGalleryRepository(
             val idColumn = cursor.getColumnIndexOrThrow(MediaStore.Images.Media._ID)
             val dateTakenColumn = cursor.getColumnIndexOrThrow(MediaStore.Images.Media.DATE_TAKEN)
             val dateAddedColumn = cursor.getColumnIndexOrThrow(MediaStore.Images.Media.DATE_ADDED)
+            val displayNameColumn = cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.DISPLAY_NAME)
             val sizeColumn = cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.SIZE)
 
             while (cursor.moveToNext()) {
                 val id = cursor.getLong(idColumn)
                 val dateTaken = cursor.getLong(dateTakenColumn)
                 val dateAdded = cursor.getLong(dateAddedColumn)
+                val displayName = cursor.getString(displayNameColumn)
                 val sizeBytes = cursor.getLong(sizeColumn).coerceAtLeast(0L)
-                val normalizedDate = if (dateTaken > 0L) dateTaken else dateAdded * 1000L
+                val normalizedDate = EditedPhotoNameCodec.resolveDateTakenMillis(
+                    dateTakenMillis = dateTaken,
+                    dateAddedSeconds = dateAdded,
+                    displayName = displayName
+                )
 
                 val contentUri = ContentUris.withAppendedId(
                     collection,
@@ -315,11 +326,16 @@ class MediaStoreGalleryRepository(
             MediaStore.Images.Media.EXTERNAL_CONTENT_URI
         }
         val insertValues = ContentValues().apply {
-            put(MediaStore.MediaColumns.DISPLAY_NAME, buildEditedDisplayName(sourceMetadata.displayName, outputMimeType))
+            put(
+                MediaStore.MediaColumns.DISPLAY_NAME,
+                EditedPhotoNameCodec.buildDisplayName(
+                    originalName = sourceMetadata.displayName,
+                    mimeType = outputMimeType,
+                    sourceDateTakenMillis = dateTakenMillis
+                )
+            )
             put(MediaStore.MediaColumns.MIME_TYPE, outputMimeType)
-            if (dateTakenMillis > 0L) {
-                put(MediaStore.Images.Media.DATE_TAKEN, dateTakenMillis)
-            }
+            putCaptureTimestampColumns(dateTakenMillis)
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                 put(MediaStore.Images.Media.IS_PENDING, 1)
                 put(
@@ -339,13 +355,16 @@ class MediaStoreGalleryRepository(
                     throw IllegalStateException("Unable to encode edited photo.")
                 }
             } ?: throw IllegalStateException("Unable to open output stream for edited photo.")
+            writeCaptureExifTimestamp(
+                targetUri = insertedUri,
+                outputMimeType = outputMimeType,
+                dateTakenMillis = dateTakenMillis
+            )
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                 val publishValues = ContentValues().apply {
                     put(MediaStore.Images.Media.IS_PENDING, 0)
-                    if (dateTakenMillis > 0L) {
-                        put(MediaStore.Images.Media.DATE_TAKEN, dateTakenMillis)
-                    }
+                    putCaptureTimestampColumns(dateTakenMillis)
                 }
                 contentResolver.update(insertedUri, publishValues, null, null)
             }
@@ -426,19 +445,6 @@ class MediaStoreGalleryRepository(
         }
     }
 
-    private fun buildEditedDisplayName(originalName: String?, mimeType: String): String {
-        val baseName = originalName
-            ?.substringBeforeLast('.', missingDelimiterValue = originalName)
-            ?.takeIf { it.isNotBlank() }
-            ?: "IMG_${System.currentTimeMillis()}"
-        val extension = when (mimeType) {
-            MIME_TYPE_PNG -> "png"
-            MIME_TYPE_WEBP -> "webp"
-            else -> "jpg"
-        }
-        return "${baseName}_edited_${System.currentTimeMillis()}.$extension"
-    }
-
     @Suppress("DEPRECATION")
     private fun compressFormatForMimeType(mimeType: String): Bitmap.CompressFormat {
         return when (mimeType) {
@@ -457,6 +463,36 @@ class MediaStoreGalleryRepository(
     private fun Cursor.getStringOrNull(columnName: String): String? {
         val index = getColumnIndex(columnName)
         return if (index >= 0 && !isNull(index)) getString(index) else null
+    }
+
+    private fun ContentValues.putCaptureTimestampColumns(dateTakenMillis: Long) {
+        if (dateTakenMillis <= 0L) return
+        val dateSeconds = (dateTakenMillis / 1_000L).coerceAtLeast(0L)
+        put(MediaStore.Images.Media.DATE_TAKEN, dateTakenMillis)
+        put(MediaStore.MediaColumns.DATE_ADDED, dateSeconds)
+        put(MediaStore.MediaColumns.DATE_MODIFIED, dateSeconds)
+    }
+
+    private fun writeCaptureExifTimestamp(
+        targetUri: Uri,
+        outputMimeType: String,
+        dateTakenMillis: Long
+    ) {
+        if (dateTakenMillis <= 0L) return
+        if (outputMimeType != MIME_TYPE_JPEG && outputMimeType != MIME_TYPE_WEBP) return
+
+        runCatching {
+            contentResolver.openFileDescriptor(targetUri, "rw")?.use { descriptor ->
+                val exif = ExifInterface(descriptor.fileDescriptor)
+                val exifDateTime = EXIF_DATE_TIME_FORMATTER.format(
+                    Instant.ofEpochMilli(dateTakenMillis).atZone(ZoneId.systemDefault())
+                )
+                exif.setAttribute(ExifInterface.TAG_DATETIME, exifDateTime)
+                exif.setAttribute(ExifInterface.TAG_DATETIME_ORIGINAL, exifDateTime)
+                exif.setAttribute(ExifInterface.TAG_DATETIME_DIGITIZED, exifDateTime)
+                exif.saveAttributes()
+            }
+        }
     }
 
     private fun buildQueryArgs(
@@ -488,6 +524,8 @@ class MediaStoreGalleryRepository(
         const val MIME_TYPE_JPEG = "image/jpeg"
         const val MIME_TYPE_PNG = "image/png"
         const val MIME_TYPE_WEBP = "image/webp"
+        val EXIF_DATE_TIME_FORMATTER: DateTimeFormatter =
+            DateTimeFormatter.ofPattern("yyyy:MM:dd HH:mm:ss", Locale.US)
         val DEFAULT_RELATIVE_PATH = "${Environment.DIRECTORY_PICTURES}/Basic Gallery"
     }
 }

--- a/app/src/test/java/com/example/basicgallery/data/EditedPhotoNameCodecTest.kt
+++ b/app/src/test/java/com/example/basicgallery/data/EditedPhotoNameCodecTest.kt
@@ -1,0 +1,86 @@
+package com.example.basicgallery.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class EditedPhotoNameCodecTest {
+
+    @Test
+    fun buildDisplayName_withSourceTimestamp_encodesSourceAndSaveTimes() {
+        val sourceTimestamp = 1_712_342_400_000L
+        val saveTimestamp = 1_712_500_000_000L
+
+        val result = EditedPhotoNameCodec.buildDisplayName(
+            originalName = "IMG_0001.jpg",
+            mimeType = "image/jpeg",
+            sourceDateTakenMillis = sourceTimestamp,
+            nowMillis = saveTimestamp
+        )
+
+        assertEquals(
+            "IMG_0001_edited_from_1712342400000_at_1712500000000.jpg",
+            result
+        )
+    }
+
+    @Test
+    fun buildDisplayName_withoutSourceTimestamp_usesEditedSaveTimePattern() {
+        val saveTimestamp = 1_712_500_000_000L
+
+        val result = EditedPhotoNameCodec.buildDisplayName(
+            originalName = "IMG_0001.jpg",
+            mimeType = "image/jpeg",
+            sourceDateTakenMillis = 0L,
+            nowMillis = saveTimestamp
+        )
+
+        assertEquals("IMG_0001_edited_1712500000000.jpg", result)
+    }
+
+    @Test
+    fun parseSourceDateTakenMillis_fromEncodedName_returnsSourceTimestamp() {
+        val result = EditedPhotoNameCodec.parseSourceDateTakenMillis(
+            "IMG_0001_edited_from_1712342400000_at_1712500000000.jpg"
+        )
+
+        assertEquals(1_712_342_400_000L, result)
+    }
+
+    @Test
+    fun parseSourceDateTakenMillis_fromNonEncodedName_returnsNull() {
+        val result = EditedPhotoNameCodec.parseSourceDateTakenMillis(
+            "IMG_0001_edited_1712500000000.jpg"
+        )
+
+        assertNull(result)
+    }
+
+    @Test
+    fun resolveDateTakenMillis_prefersEncodedSourceTimestamp() {
+        val result = EditedPhotoNameCodec.resolveDateTakenMillis(
+            dateTakenMillis = 1_712_500_000_000L,
+            dateAddedSeconds = 1_712_500_000L,
+            displayName = "IMG_0001_edited_from_1712342400000_at_1712500000000.jpg"
+        )
+
+        assertEquals(1_712_342_400_000L, result)
+    }
+
+    @Test
+    fun resolveDateTakenMillis_fallsBackToMediaStoreColumns() {
+        val withDateTaken = EditedPhotoNameCodec.resolveDateTakenMillis(
+            dateTakenMillis = 1_700_000_000_000L,
+            dateAddedSeconds = 1_600_000_000L,
+            displayName = "IMG_regular.jpg"
+        )
+        val withDateAdded = EditedPhotoNameCodec.resolveDateTakenMillis(
+            dateTakenMillis = 0L,
+            dateAddedSeconds = 1_600_000_000L,
+            displayName = "IMG_regular.jpg"
+        )
+
+        assertEquals(1_700_000_000_000L, withDateTaken)
+        assertEquals(1_600_000_000_000L, withDateAdded)
+    }
+}


### PR DESCRIPTION
### Description of Changes

This pull request introduces a new `EditedPhotoNameCodec` component for encoding and decoding metadata related to edited photos. The codec has been integrated into the `MediaStoreGalleryRepository`, and associated tests have been added to ensure the functionality works as expected.

