### PR TITLE
Add scrollbar to GalleryScreen for large grid navigation

### DIFF
--- a/app/src/androidTest/java/com/example/basicgallery/ui/gallery/GalleryScreenScrollbarTest.kt
+++ b/app/src/androidTest/java/com/example/basicgallery/ui/gallery/GalleryScreenScrollbarTest.kt
@@ -1,0 +1,114 @@
+package com.example.basicgallery.ui.gallery
+
+import android.net.Uri
+import androidx.activity.ComponentActivity
+import androidx.compose.foundation.lazy.grid.LazyGridState
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import coil.ImageLoader
+import com.example.basicgallery.data.model.PhotoItem
+import com.example.basicgallery.ui.theme.BasicGalleryTheme
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class GalleryScreenScrollbarTest {
+
+    @get:Rule
+    val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun photosGrid_scrollbarAppearsOnlyWhileScrolling() {
+        lateinit var gridState: LazyGridState
+        lateinit var scrollScope: CoroutineScope
+
+        setGalleryContent(
+            uiState = GalleryUiState(
+                photos = createPhotos(count = 240),
+                photoCount = 240
+            ),
+            onStateReady = { readyGridState, readyScope ->
+                gridState = readyGridState
+                scrollScope = readyScope
+            }
+        )
+
+        composeRule.onNodeWithTag(GALLERY_GRID_TAG).assertExists()
+        composeRule.onNodeWithTag(GALLERY_SCROLLBAR_TAG).assertDoesNotExist()
+
+        composeRule.mainClock.autoAdvance = false
+        composeRule.runOnIdle {
+            scrollScope.launch {
+                gridState.animateScrollToItem(index = 180)
+            }
+        }
+
+        composeRule.mainClock.advanceTimeBy(96L)
+        composeRule.runOnIdle {}
+        composeRule.onNodeWithTag(GALLERY_SCROLLBAR_TAG).assertExists()
+
+        composeRule.mainClock.autoAdvance = true
+        composeRule.waitForIdle()
+        composeRule.onNodeWithTag(GALLERY_SCROLLBAR_TAG).assertDoesNotExist()
+    }
+
+    private fun setGalleryContent(
+        uiState: GalleryUiState,
+        onStateReady: (LazyGridState, CoroutineScope) -> Unit
+    ) {
+        composeRule.setContent {
+            var currentTab by remember { mutableStateOf(GalleryTab.PHOTOS) }
+            val context = LocalContext.current
+            val imageLoader = remember(context) {
+                ImageLoader.Builder(context).build()
+            }
+            val gridState = rememberLazyGridState()
+            val scope = rememberCoroutineScope()
+            SideEffect {
+                onStateReady(gridState, scope)
+            }
+
+            BasicGalleryTheme {
+                GalleryScreen(
+                    uiState = uiState,
+                    imageLoader = imageLoader,
+                    currentTab = currentTab,
+                    gridState = gridState,
+                    onTabSelected = { currentTab = it },
+                    onPhotoClick = {},
+                    onPhotoLongClick = {},
+                    onSelectPhotos = {},
+                    onDeleteSelected = {},
+                    onRestoreSelected = {},
+                    onDeleteSelectedFromTrash = {},
+                    onDeleteAllFromTrash = {},
+                    onClearSelection = {},
+                    onRetry = {}
+                )
+            }
+        }
+    }
+
+    private fun createPhotos(count: Int): List<PhotoItem> {
+        val nowMillis = System.currentTimeMillis()
+        return List(count) { index ->
+            PhotoItem(
+                id = index.toLong() + 1L,
+                contentUri = Uri.parse("content://test/photo/${index + 1}"),
+                dateTakenMillis = nowMillis - index * 60_000L
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/basicgallery/ui/gallery/GalleryScreen.kt
+++ b/app/src/main/java/com/example/basicgallery/ui/gallery/GalleryScreen.kt
@@ -22,6 +22,7 @@ import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.IntentSenderRequest
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.gestures.detectDragGestures
@@ -36,11 +37,13 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyGridState
@@ -65,6 +68,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -73,7 +77,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.viewinterop.AndroidView
+import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -121,6 +127,8 @@ internal const val GALLERY_TOP_APP_BAR_TAG = "gallery_top_app_bar"
 internal const val GALLERY_TAB_ROW_TAG = "gallery_tab_row"
 internal const val GALLERY_TAB_PHOTOS_TAG = "gallery_tab_photos"
 internal const val GALLERY_TAB_TRASH_TAG = "gallery_tab_trash"
+internal const val GALLERY_GRID_TAG = "gallery_grid"
+internal const val GALLERY_SCROLLBAR_TAG = "gallery_scrollbar"
 
 internal enum class GalleryTab {
     PHOTOS,
@@ -130,6 +138,34 @@ internal enum class GalleryTab {
 private data class PendingMediaRequest(
     val closeViewerAfterSuccess: Boolean
 )
+
+internal data class GridScrollbarMetrics(
+    val thumbOffsetFraction: Float,
+    val thumbHeightFraction: Float
+)
+
+internal fun calculateGridScrollbarMetrics(
+    totalItemsCount: Int,
+    firstVisibleItemIndex: Int,
+    visibleItemsCount: Int,
+    minThumbHeightFraction: Float = 0.12f
+): GridScrollbarMetrics? {
+    if (totalItemsCount <= 0 || visibleItemsCount <= 0 || visibleItemsCount >= totalItemsCount) {
+        return null
+    }
+
+    val clampedMinFraction = minThumbHeightFraction.coerceIn(0f, 1f)
+    val thumbHeightFraction = (visibleItemsCount.toFloat() / totalItemsCount.toFloat())
+        .coerceIn(clampedMinFraction, 1f)
+    val maxFirstIndex = (totalItemsCount - visibleItemsCount).coerceAtLeast(1)
+    val thumbOffsetFraction = (firstVisibleItemIndex.toFloat() / maxFirstIndex.toFloat())
+        .coerceIn(0f, 1f)
+
+    return GridScrollbarMetrics(
+        thumbOffsetFraction = thumbOffsetFraction,
+        thumbHeightFraction = thumbHeightFraction
+    )
+}
 
 internal fun createFullscreenDeleteHandler(
     openedFromTrash: Boolean,
@@ -480,6 +516,19 @@ internal fun GalleryScreen(
     } else {
         stringResource(id = R.string.gallery_empty_state)
     }
+    val scrollbarMetrics by remember(gridState) {
+        derivedStateOf {
+            val layoutInfo = gridState.layoutInfo
+            val firstVisibleIndex = layoutInfo.visibleItemsInfo.minOfOrNull { item -> item.index }
+                ?: return@derivedStateOf null
+            calculateGridScrollbarMetrics(
+                totalItemsCount = layoutInfo.totalItemsCount,
+                firstVisibleItemIndex = firstVisibleIndex,
+                visibleItemsCount = layoutInfo.visibleItemsInfo.size
+            )
+        }
+    }
+    val showScrollbar = gridState.isScrollInProgress && scrollbarMetrics != null
 
     val pullToRevealConnection = remember(maxRevealDistancePx) {
         object : NestedScrollConnection {
@@ -605,45 +654,59 @@ internal fun GalleryScreen(
                 }
 
                 else -> {
-                    LazyVerticalGrid(
-                        columns = GridCells.Fixed(3),
-                        state = gridState,
-                        contentPadding = PaddingValues(2.dp),
-                        verticalArrangement = Arrangement.spacedBy(2.dp),
-                        horizontalArrangement = Arrangement.spacedBy(2.dp),
-                        modifier = Modifier.fillMaxSize()
-                    ) {
-                        photoSections.forEach { section ->
-                            item(
-                                key = "header_${section.day.toEpochDay()}",
-                                span = { GridItemSpan(maxLineSpan) },
-                                contentType = "day_header"
-                            ) {
-                                DaySectionHeader(
-                                    label = section.label,
-                                    showSelectAll = !isTrashTab,
-                                    isSelectAllEnabled = section.photos.any { photo ->
-                                        photo.id !in uiState.selectedPhotoIds
-                                    },
-                                    onSelectAll = {
-                                        onSelectPhotos(section.photos.map { photo -> photo.id })
-                                    }
-                                )
-                            }
+                    Box(modifier = Modifier.fillMaxSize()) {
+                        LazyVerticalGrid(
+                            columns = GridCells.Fixed(3),
+                            state = gridState,
+                            contentPadding = PaddingValues(2.dp),
+                            verticalArrangement = Arrangement.spacedBy(2.dp),
+                            horizontalArrangement = Arrangement.spacedBy(2.dp),
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .testTag(GALLERY_GRID_TAG)
+                        ) {
+                            photoSections.forEach { section ->
+                                item(
+                                    key = "header_${section.day.toEpochDay()}",
+                                    span = { GridItemSpan(maxLineSpan) },
+                                    contentType = "day_header"
+                                ) {
+                                    DaySectionHeader(
+                                        label = section.label,
+                                        showSelectAll = !isTrashTab,
+                                        isSelectAllEnabled = section.photos.any { photo ->
+                                            photo.id !in uiState.selectedPhotoIds
+                                        },
+                                        onSelectAll = {
+                                            onSelectPhotos(section.photos.map { photo -> photo.id })
+                                        }
+                                    )
+                                }
 
-                            items(
-                                items = section.photos,
-                                key = { it.id },
-                                contentType = { "photo" }
-                            ) { photo ->
-                                PhotoGridItem(
-                                    photo = photo,
-                                    imageLoader = imageLoader,
-                                    isSelected = photo.id in uiState.selectedPhotoIds,
-                                    onClick = { onPhotoClick(photo) },
-                                    onLongClick = { onPhotoLongClick(photo) }
-                                )
+                                items(
+                                    items = section.photos,
+                                    key = { it.id },
+                                    contentType = { "photo" }
+                                ) { photo ->
+                                    PhotoGridItem(
+                                        photo = photo,
+                                        imageLoader = imageLoader,
+                                        isSelected = photo.id in uiState.selectedPhotoIds,
+                                        onClick = { onPhotoClick(photo) },
+                                        onLongClick = { onPhotoLongClick(photo) }
+                                    )
+                                }
                             }
+                        }
+
+                        if (showScrollbar && scrollbarMetrics != null) {
+                            GalleryGridScrollbar(
+                                metrics = scrollbarMetrics,
+                                modifier = Modifier
+                                    .align(Alignment.CenterEnd)
+                                    .padding(vertical = 6.dp, horizontal = 4.dp)
+                                    .testTag(GALLERY_SCROLLBAR_TAG)
+                            )
                         }
                     }
                 }
@@ -675,6 +738,43 @@ internal fun GalleryScreen(
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun GalleryGridScrollbar(
+    metrics: GridScrollbarMetrics?,
+    modifier: Modifier = Modifier
+) {
+    if (metrics == null) return
+
+    val trackColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.14f)
+    val thumbColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.52f)
+
+    Canvas(
+        modifier = modifier
+            .fillMaxHeight(0.92f)
+            .width(4.dp)
+    ) {
+        if (size.height <= 0f || size.width <= 0f) return@Canvas
+
+        val cornerRadius = CornerRadius(x = size.width / 2f, y = size.width / 2f)
+        drawRoundRect(
+            color = trackColor,
+            size = size,
+            cornerRadius = cornerRadius
+        )
+
+        val thumbHeight = (size.height * metrics.thumbHeightFraction).coerceIn(0f, size.height)
+        val maxThumbOffset = (size.height - thumbHeight).coerceAtLeast(0f)
+        val thumbTop = (metrics.thumbOffsetFraction * maxThumbOffset).coerceIn(0f, maxThumbOffset)
+
+        drawRoundRect(
+            color = thumbColor,
+            topLeft = Offset(x = 0f, y = thumbTop),
+            size = Size(width = size.width, height = thumbHeight),
+            cornerRadius = cornerRadius
+        )
     }
 }
 

--- a/app/src/test/java/com/example/basicgallery/ui/gallery/GridScrollbarMetricsTest.kt
+++ b/app/src/test/java/com/example/basicgallery/ui/gallery/GridScrollbarMetricsTest.kt
@@ -1,0 +1,45 @@
+package com.example.basicgallery.ui.gallery
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class GridScrollbarMetricsTest {
+
+    @Test
+    fun calculateGridScrollbarMetrics_whenAllItemsFit_returnsNull() {
+        val metrics = calculateGridScrollbarMetrics(
+            totalItemsCount = 12,
+            firstVisibleItemIndex = 0,
+            visibleItemsCount = 12
+        )
+
+        assertNull(metrics)
+    }
+
+    @Test
+    fun calculateGridScrollbarMetrics_calculatesThumbSizeAndOffsetFractions() {
+        val metrics = calculateGridScrollbarMetrics(
+            totalItemsCount = 100,
+            firstVisibleItemIndex = 30,
+            visibleItemsCount = 20
+        )
+
+        requireNotNull(metrics)
+        assertEquals(0.2f, metrics.thumbHeightFraction, 0.0001f)
+        assertEquals(0.375f, metrics.thumbOffsetFraction, 0.0001f)
+    }
+
+    @Test
+    fun calculateGridScrollbarMetrics_appliesMinimumThumbAndClampsOffset() {
+        val metrics = calculateGridScrollbarMetrics(
+            totalItemsCount = 500,
+            firstVisibleItemIndex = 9_999,
+            visibleItemsCount = 1
+        )
+
+        requireNotNull(metrics)
+        assertEquals(0.12f, metrics.thumbHeightFraction, 0.0001f)
+        assertEquals(1f, metrics.thumbOffsetFraction, 0.0001f)
+    }
+}


### PR DESCRIPTION
Added a scrollbar to the `GalleryScreen` to improve navigation in large grids. Supplemented the feature with tests to ensure reliability and functionality.