### PR TITLE
Add GitHub Actions workflow for automated APK builds on release tags

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,55 @@
+name: Build Release APK
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    name: Build APK
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          cache: 'gradle'
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+
+      - name: Build debug APK
+        run: ./gradlew assembleDebug --no-daemon
+
+      - name: Build release APK (unsigned)
+        run: ./gradlew assembleRelease --no-daemon
+
+      - name: Upload debug APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-debug
+          path: app/build/outputs/apk/debug/app-debug.apk
+          retention-days: 14
+
+      - name: Upload release APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-release-unsigned
+          path: app/build/outputs/apk/release/app-release-unsigned.apk
+          retention-days: 14
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: "Release ${{ github.ref_name }}"
+          draft: false
+          prerelease: false
+          files: |
+            app/build/outputs/apk/debug/app-debug.apk
+            app/build/outputs/apk/release/app-release-unsigned.apk


### PR DESCRIPTION
## Summary
This PR introduces a new GitHub Actions workflow that automatically builds and releases APK artifacts when a version tag is pushed to the repository.

## Key Changes
- Added `.github/workflows/build-release.yml` workflow file that:
  - Triggers on push events matching version tags (v*)
  - Sets up JDK 11 with Gradle caching for faster builds
  - Builds both debug and release (unsigned) APK variants
  - Uploads APK artifacts with 14-day retention
  - Creates a GitHub Release with both APK files attached

## Implementation Details
- Uses `ubuntu-latest` runner for consistent build environment
- Leverages Gradle caching via `actions/setup-java@v4` to improve build performance
- Builds unsigned release APK (suitable for manual signing or distribution)
- Automatically creates GitHub Releases with descriptive names based on tag
- Retains build artifacts for 14 days for easy access and debugging

https://claude.ai/code/session_018s3bWaJn256h9koGGfurZA